### PR TITLE
Suppress pyraf task listing

### DIFF
--- a/src/ossos-pipeline/pymop/pymop/astrometry/daophot.py
+++ b/src/ossos-pipeline/pymop/pymop/astrometry/daophot.py
@@ -41,7 +41,7 @@ def phot(fitsimage, x_in, y_in, aperture=15, sky=20, swidth=10, apcor=0.3,
     iraf.set(uparm="./")
     iraf.digiphot()
     iraf.apphot()
-    iraf.daophot()
+    iraf.daophot(_doprint=0)
 
     ### check for the magical 'zeropoint.used' file
     zpu_file = "zeropoint.used"


### PR DESCRIPTION
Set flag to turn off pyraf's default behaviour of printing the names of the tasks in a package when that package is loaded.
