### PR TITLE
Write empty candidates file if no sources accepted

### DIFF
--- a/src/ossos-pipeline/pymop/pymop/gui/models.py
+++ b/src/ossos-pipeline/pymop/pymop/gui/models.py
@@ -12,7 +12,7 @@ from wx.lib.pubsub import setupv1
 from wx.lib.pubsub import Publisher as pub
 
 from pymop.io.mpc import MPCWriter
-from pymop.io.astrom import AstromWriter
+from pymop.io.astrom import StreamingAstromWriter
 
 # Pub/Sub ids
 MSG_ROOT = ("astrodataroot", )
@@ -314,8 +314,8 @@ class ProcessCandidatesModel(AbstractModel):
             output_filehandle = open(output_filename, "wb")
             self.outputfiles.append(output_filehandle)
 
-            writer = AstromWriter(output_filehandle)
-            writer.write_headers(astrom_data.observations, astrom_data.sys_header)
+            writer = StreamingAstromWriter(output_filehandle,
+                                           astrom_data.sys_header)
             self.writers.append(writer)
 
     def _create_vettable_items(self):


### PR DESCRIPTION
This is part of the solution for #25.  However, there will still be an error when trying to load an empty candidate file, so the issue should not be closed.  The fix for the error is pretty simple, but to avoid conflicts I want to do it after some changes I am making in the AstromWorkload class as part of #8 are merged in, so it will be a separate pull request after that work is merged in.
