### PR TITLE
Increased image cutout field of view to 500x500.

### DIFF
--- a/src/ossos-pipeline/ossos/gui/config.json
+++ b/src/ossos-pipeline/ossos/gui/config.json
@@ -9,8 +9,8 @@
 
     "IMG_RETRIEVAL": {
         "DATASET_ROOT": "vos://cadc.nrc.ca~vospace/OSSOS/dbimages",
-        "DEFAULT_SLICE_ROWS": 256,
-        "DEFAULT_SLICE_COLS": 256
+        "DEFAULT_SLICE_ROWS": 500,
+        "DEFAULT_SLICE_COLS": 500
     },
 
     "MPC": {


### PR DESCRIPTION
This partially addresses #50.  It does not do centering on the middle object (instead of the first), which is still to be done.
