### PR TITLE
Use cadc shortcut in vos clients to avoid some connection overheads.

### DIFF
--- a/src/ossos-pipeline/ossos/gui/downloads.py
+++ b/src/ossos-pipeline/ossos/gui/downloads.py
@@ -139,7 +139,10 @@ class ImageSliceDownloader(object):
         self.slice_rows = slice_rows
         self.slice_cols = slice_cols
 
-        self.vosclient = vos.Client() if vosclient is None else vosclient
+        if vosclient is None:
+            self.vosclient = vos.Client(cadc_short_cut=True)
+        else:
+            self.vosclient = vosclient
 
         self.cutout_calculator = CutoutCalculator(slice_rows, slice_cols)
 

--- a/src/ossos-pipeline/ossos/storage.py
+++ b/src/ossos-pipeline/ossos/storage.py
@@ -17,7 +17,7 @@ CERTFILE=os.path.join(os.getenv('HOME'),
 DBIMAGES='vos:OSSOS/dbimages'
 DATA_WEB_SERVICE='https://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/data/pub/'
 OSSOS_TAG_URI_BASE='ivo://canfar.uvic.ca/ossos'
-vospace = vos.Client(certFile=CERTFILE)
+vospace = vos.Client(cadc_short_cut=True, certFile=CERTFILE)
 SUCCESS = 'success' 
 
 def populate(dataset_name,


### PR DESCRIPTION
@ijiraq note I switched over the client in storage.py as well.

Closes #71.
