### PR TITLE
Loading partial progress for candidates now fast-forwards

### DIFF
--- a/src/ossos-pipeline/ossos/gui/workload.py
+++ b/src/ossos-pipeline/ossos/gui/workload.py
@@ -234,6 +234,8 @@ class RealsWorkUnit(WorkUnit):
             filename, parsed_data, progress_manager, results_writer)
 
     def next_item(self):
+        assert not self.is_finished()
+
         self.next_obs()
         while self.is_current_item_processed():
             self._next_sequential_item()
@@ -284,7 +286,11 @@ class CandidatesWorkUnit(WorkUnit):
             filename, parsed_data, progress_manager, results_writer)
 
     def next_item(self):
+        assert not self.is_finished()
+
         self.next_source()
+        while self.is_current_item_processed():
+            self.next_source()
 
     def get_current_item(self):
         return self.get_current_source()


### PR DESCRIPTION
Fixed problem when processing candidates where next_item only went to the next source, not the next unprocessed source.  This meant when reloading from partial progress in a file you would only get bumped up to the second source, and if you had really already processed that one the image wouldn't get downloaded again.  Therefore you were left with an image loading dialog forever.

Closes #80.
