### PR TITLE
One MPC file per object

### DIFF
--- a/src/ossos-pipeline/ossos/astrom.py
+++ b/src/ossos-pipeline/ossos/astrom.py
@@ -388,6 +388,7 @@ class Source(object):
 
     def __init__(self, readings):
         self.readings = readings
+        self.provisional_name = None
 
     def get_reading(self, index):
         return self.readings[index]
@@ -397,6 +398,15 @@ class Source(object):
 
     def num_readings(self):
         return len(self.readings)
+
+    def has_provisional_name(self):
+        return self.provisional_name is not None
+
+    def get_provisional_name(self):
+        return self.provisional_name
+
+    def set_provisional_name(self, provisional_name):
+        self.provisional_name = provisional_name
 
 
 class SourceReading(object):

--- a/src/ossos-pipeline/ossos/gui/models.py
+++ b/src/ossos-pipeline/ossos/gui/models.py
@@ -180,6 +180,15 @@ class UIModel(object):
         except ImageNotLoadedException:
             return self.get_current_reading().dec
 
+    def is_current_source_named(self):
+        return self.get_current_source().has_provisional_name()
+
+    def get_current_source_name(self):
+        return self.get_current_source().get_provisional_name()
+
+    def set_current_source_name(self, name):
+        return self.get_current_source().set_provisional_name(name)
+
     def get_current_image(self):
         return self._get_current_image_reading().get_image()
 
@@ -244,9 +253,6 @@ class UIModel(object):
             # Nothing to unlock
             pass
 
-        for workunit in self.work_units:
-            workunit.get_writer().close()
-
         self.download_manager.stop_download()
         self.download_manager.wait_for_downloads_to_stop()
 
@@ -267,11 +273,12 @@ class UIModel(object):
         self._image_reading_models[reading] = ImageReading(reading, image)
         events.send(events.IMG_LOADED, reading)
 
-    def _on_finished_workunit(self, results_file_path):
-        events.send(events.FINISHED_WORKUNIT, results_file_path)
+    def _on_finished_workunit(self, results_file_paths):
+        events.send(events.FINISHED_WORKUNIT, results_file_paths)
 
         if self.synchronization_manager:
-            self.synchronization_manager.add_syncable_file(results_file_path)
+            for path in results_file_paths:
+                self.synchronization_manager.add_syncable_file(path)
 
 
 class ImageReading(object):
@@ -380,3 +387,4 @@ class ImageReading(object):
                                          wcs.parse_cd(fits_header),
                                          wcs.parse_pv(fits_header),
                                          wcs.parse_order_fit(fits_header))
+

--- a/src/ossos-pipeline/tests/test_integration/test_models.py
+++ b/src/ossos-pipeline/tests/test_integration/test_models.py
@@ -27,6 +27,8 @@ EMPTY_DIR = "data/empty"
 FRESH_TEST_DIR = "data/model_persistence_fresh"
 TEST_FILES = ["xxx1.cands.astrom", "xxx2.cands.astrom", "xxx3.reals.astrom", "xxx4.reals.astrom"]
 
+TEST_OBJECT_NAME = "O13AE0Z"
+
 
 class GeneralModelTest(FileReadingTestCase, DirectoryCleaningTestCase):
     def setUp(self):
@@ -372,6 +374,8 @@ class ProcessRealsModelTest(GeneralModelTest):
         assert_that(observer.on_change_img.call_count, equal_to(3))
 
     def test_next_item_after_validate_last(self):
+        self.model.set_current_source_name(TEST_OBJECT_NAME)
+
         assert_that(self.model.get_current_source_number(), equal_to(0))
         assert_that(self.model.get_current_obs_number(), equal_to(0))
 
@@ -434,6 +438,8 @@ class ProcessRealsModelTest(GeneralModelTest):
         assert_that(self.model.get_current_obs_number(), equal_to(2))
 
     def test_is_source_discovered(self):
+        self.model.set_current_source_name(TEST_OBJECT_NAME)
+
         assert_that(self.model.is_current_source_discovered(), equal_to(False))
         self.model.reject_current_item()
         assert_that(self.model.is_current_source_discovered(), equal_to(False))
@@ -497,6 +503,7 @@ class ProcessRealsModelTest(GeneralModelTest):
         total_items = 9
         item = 0
         while item < total_items - 1:
+            self.model.set_current_source_name(TEST_OBJECT_NAME)
             self.model.accept_current_item()
             assert_that(observer.on_all_processed.call_count, equal_to(0))
             self.model.next_item()
@@ -515,6 +522,7 @@ class ProcessRealsModelTest(GeneralModelTest):
         total_items = 9
         item = 0
         while item < total_items - 1:
+            self.model.set_current_source_name(TEST_OBJECT_NAME)
             self.model.accept_current_item()
             assert_that(observer.on_all_processed.call_count, equal_to(0))
             self.model.next_item()
@@ -824,6 +832,8 @@ class RealsModelPersistenceTest(GeneralModelTest):
         assert_that(self.concurrent_progress_manager.get_processed_indices(first_file),
                     has_length(0))
 
+        self.model.set_current_source_name(TEST_OBJECT_NAME)
+
         self.model.accept_current_item()
         assert_that(self.concurrent_progress_manager.is_done(first_file),
                     equal_to(False))
@@ -850,6 +860,8 @@ class RealsModelPersistenceTest(GeneralModelTest):
         assert_that(self.concurrent_progress_manager.get_processed_indices(first_file),
                     has_length(0))
 
+        self.model.set_current_source_name(TEST_OBJECT_NAME)
+
         # source 1 of 3, reading 1 of 3
         self.model.accept_current_item()
         self.model.next_item()
@@ -865,6 +877,8 @@ class RealsModelPersistenceTest(GeneralModelTest):
                     equal_to(False))
         assert_that(self.concurrent_progress_manager.get_processed_indices(first_file),
                     contains_inanyorder(0))
+
+        self.model.set_current_source_name(TEST_OBJECT_NAME)
 
         # source 2 of 3 reading 1 of 3
         self.model.accept_current_item()
@@ -885,6 +899,8 @@ class RealsModelPersistenceTest(GeneralModelTest):
                     equal_to(False))
         assert_that(self.concurrent_progress_manager.get_processed_indices(first_file),
                     contains_inanyorder(0, 1))
+
+        self.model.set_current_source_name(TEST_OBJECT_NAME)
 
         # source 3 of 3 reading 1 of 3
         self.model.next_item()
@@ -914,6 +930,7 @@ class RealsModelPersistenceTest(GeneralModelTest):
         accepts_before_next_file = 9
 
         while accepts_before_next_file > 1:
+            self.model.set_current_source_name(TEST_OBJECT_NAME)
             self.model.accept_current_item()
             self.model.next_item()
             assert_that(observer.on_file_processed.call_count, equal_to(0))
@@ -928,7 +945,7 @@ class RealsModelPersistenceTest(GeneralModelTest):
 
         msg = args[0]
         assert_that(msg.topic, equal_to(events.FINISHED_WORKUNIT))
-        assert_that(msg.data, equal_to(workunit.get_results_file_path()))
+        assert_that(msg.data, equal_to(workunit.get_results_file_paths()))
 
     def test_unlock_on_exit(self):
         current_file = self.model.get_current_filename()
@@ -969,6 +986,8 @@ class RealsModelPersistenceLoadingTest(GeneralModelTest):
         return ["xxx1.cands.astrom", "xxx3.reals.astrom"]
 
     def test_load_partially_processed(self):
+        self.model.set_current_source_name(TEST_OBJECT_NAME)
+
         observer = Mock()
         events.subscribe(events.FINISHED_WORKUNIT, observer)
 
@@ -988,7 +1007,7 @@ class RealsModelPersistenceLoadingTest(GeneralModelTest):
         assert_that(observer.call_count, equal_to(1))
 
         msg = observer.call_args_list[0][0][0]
-        assert_that(msg.data, equal_to(workunit.get_results_file_path()))
+        assert_that(msg.data, equal_to(workunit.get_results_file_paths()))
 
 
 class CandidatesModelPersistenceTest(GeneralModelTest):
@@ -1119,7 +1138,7 @@ class CandidatesModelPersistenceLoadingTest(GeneralModelTest):
         assert_that(observer.call_count, equal_to(1))
 
         msg = observer.call_args_list[0][0][0]
-        assert_that(msg.data, equal_to(workunit.get_results_file_path()))
+        assert_that(msg.data, equal_to(workunit.get_results_file_paths()))
 
     def test_load_fast_forward_through_sources(self):
         self.create_part_file_with_indices([0, 1])


### PR DESCRIPTION
Only one object is put in each MPC file, and the file is named after the source.  The source is named when it is first accepted or rejected.
Closes #127
