### PR TITLE
ImageNotLoadedExceptions handling

### DIFF
--- a/src/ossos-pipeline/ossos/gui/controllers.py
+++ b/src/ossos-pipeline/ossos/gui/controllers.py
@@ -54,7 +54,10 @@ class AbstractController(object):
         self.get_view().draw_circle(image_x, image_y, radius, redraw=True)
 
     def on_reposition_source(self, new_x, new_y):
-        self.model.update_current_source_location((new_x, new_y))
+        try:
+            self.model.update_current_source_location((new_x, new_y))
+        except ImageNotLoadedException:
+            pass
 
     def on_image_loaded(self, event):
         source_reading = event.data
@@ -126,8 +129,11 @@ class AbstractController(object):
         raise NotImplementedError()
 
     def on_reset_source_location(self):
-        self.model.reset_current_source_location()
-        self.circle_current_source()
+        try:
+            self.model.reset_current_source_location()
+            self.circle_current_source()
+        except ImageNotLoadedException:
+            pass
 
 
 class ProcessRealsController(AbstractController):


### PR DESCRIPTION
Ignore ImageNotLoadedExceptions arising from the user clicking in the image viewer or trying to recentroid while the image is not yet loaded.
