### PR TITLE
Track cutout focus

### DIFF
--- a/src/ossos-pipeline/ossos/gui/models/imagemanager.py
+++ b/src/ossos-pipeline/ossos/gui/models/imagemanager.py
@@ -49,7 +49,13 @@ class ImageManager(object):
         focus_calculator = SingletFocusCalculator(source)
 
         for reading in source.get_readings():
-            focus = focus_calculator.calculate_focus(reading)
+            if reading.ssos:
+                # For track the objects have moved too far to center on
+                # the mid point.  Centre each image on its source reading.
+                # TODO: refactor.
+                focus = reading.source_point
+            else:
+                focus = focus_calculator.calculate_focus(reading)
             self._singlet_download_manager.submit_request(
                 DownloadRequest(reading,
                                 needs_apcor=needs_apcor,


### PR DESCRIPTION
Changed focus for track to be on each reading's source point instead of
the source point of the middle reading.  This is needed because in track
the time period is much larger and the readings are not all in the same 
field of view.
