### PR TITLE
Track autoflush

### DIFF
--- a/src/ossos-pipeline/ossos/gui/models/workload.py
+++ b/src/ossos-pipeline/ossos/gui/models/workload.py
@@ -240,7 +240,7 @@ class TracksWorkUnit(WorkUnit):
         from ossos.mpc import MPCWriter
 
         return MPCWriter(self.output_context.open(filename),
-                         auto_flush=False)
+                         auto_flush=True)
 
     def _get_item_set(self):
         all_readings = set()


### PR DESCRIPTION
Track workunits now flush their mpc lines as they are generated.

This should allow the user to accept some of the sources, quit the application, rename the mpc file to .track, and re-run the process as a workaround until this is automated within the application.
