### PR TITLE
Update ra dec

### DIFF
--- a/src/ossos-pipeline/ossos/downloads/cutouts/source.py
+++ b/src/ossos-pipeline/ossos/downloads/cutouts/source.py
@@ -145,7 +145,7 @@ class SourceCutout(object):
     def _update_ra_dec(self):
         fits_header = self.get_fits_header()
 
-        self._ra, self._dec = wcs.xy2sky(self.observed_x, self.observed_y,
+        self._ra, self._dec = wcs.xy2sky(self.pixel_x, self.pixel_y,
                                          float(fits_header[astrom.CRPIX1]),
                                          float(fits_header[astrom.CRPIX2]),
                                          float(fits_header[astrom.CRVAL1]),


### PR DESCRIPTION
Updating the RA/DEC for a source cutout now calls xy2sky with the pixel
coordinates in the cutout since the FITS header values of CRPIX1 and 
CRPIX2 are adjusted when the cutout is retrieved.
