### PR TITLE
Migrated vospace integration tests

### DIFF
--- a/src/ossos-pipeline/tests/test_vospace/test_vospace_context.py
+++ b/src/ossos-pipeline/tests/test_vospace/test_vospace_context.py
@@ -6,9 +6,7 @@ from hamcrest import assert_that, equal_to, contains_inanyorder
 
 from ossos.gui.context import VOSpaceWorkingContext
 
-# TODO: don't use my own VOSpace
-# BASE_TEST_DIR = "vos:OSSOS/tests/"
-BASE_TEST_DIR = "vos:drusk/OSSOS/tests/"
+BASE_TEST_DIR = "vos:OSSOS/integration_tests/"
 LISTING_TEST_DIR = BASE_TEST_DIR + "listing_test"
 
 

--- a/src/ossos-pipeline/tests/test_vospace/test_vospace_persistence.py
+++ b/src/ossos-pipeline/tests/test_vospace/test_vospace_persistence.py
@@ -12,9 +12,7 @@ from ossos.gui.context import VOSpaceWorkingContext
 from ossos.gui import progress
 from ossos.gui.progress import VOSpaceProgressManager, FileLockedException, RequiresLockException
 
-# TODO: don't use my own VOSpace
-# BASE_TEST_DIR = "vos:OSSOS/tests/"
-BASE_TEST_DIR = "vos:drusk/OSSOS/tests/"
+BASE_TEST_DIR = "vos:OSSOS/integration_tests/"
 PROTOTYPE_FILE = "data/prototype"
 PERSISTENCE_TEST_DIR = BASE_TEST_DIR + "persistence_tests"
 


### PR DESCRIPTION
Migrated vospace integration tests from using my personal vospace to using vos:OSSOS/integration_tests.
