### PR TITLE
Make combine and measure3 processes that can be run standalone.

### DIFF
--- a/src/ossos/core/ossos/pipeline/measure3.py
+++ b/src/ossos/core/ossos/pipeline/measure3.py
@@ -94,6 +94,7 @@ def run(base_image, dbimages=None):
 
         astrometry_lines = {}
         for base_name in xy_files:
+            storage.get_frame(base_name)
             xy_files[base_name].close()
             cmd = 'xy2skypv %s.fits %s.xy %s.rd' % (base_name,
                                                     base_name, base_name)


### PR DESCRIPTION
During some pipeline restarts we want to be able to run combine as its own step.  Need to retrieve fits images to make this possible.  Modified measure3 to a module as well as executable during this step.