### PR TITLE
Changed SSOIS URL in ssos.py to https

### DIFF
--- a/src/ossos/core/ossos/ssos.py
+++ b/src/ossos/core/ossos/ssos.py
@@ -21,7 +21,7 @@ requests.packages.urllib3.disable_warnings()
 __author__ = 'Michele Bannister, JJ Kavelaars'
 
 # SSOS_URL = "http://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/cadcbin/ssos/ssos.pl"
-SSOS_URL = "http://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/cadcbin/ssos/ssosclf.pl"
+SSOS_URL = "https://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/cadcbin/ssos/ssosclf.pl"
 RESPONSE_FORMAT = 'tsv'
 NEW_LINE = '\r\n'
 


### PR DESCRIPTION
Changing the SSOIS URL from http to https will allow the requests.post() function to work properly. The function had trouble calling the SSOIS API using the old URL.